### PR TITLE
Segfault fix

### DIFF
--- a/R/cost_functions.R
+++ b/R/cost_functions.R
@@ -442,15 +442,16 @@ likelihood_lm3ppa <- function(
   GPP <- LAI <- Density12 <- plantC <- error <- NULL
   
   # Add changed model parameters to drivers, overwriting where necessary.
-  drivers$params_species[[1]]$phiRL[]      <- par[1]
+  drivers$params_species[[1]]$phiRL[]  <- par[1]
   drivers$params_species[[1]]$LAI_light[]  <- par[2]
-  drivers$params_tile[[1]]$tf_base         <- par[3]
-  drivers$params_tile[[1]]$par_mort        <- par[4]
+  
+  drivers$params_tile[[1]]$tf_base <- par[3]
+  drivers$params_tile[[1]]$par_mort <- par[4]
   
   # run model
   df <- runread_lm3ppa_f(
     drivers,
-    makecheck = TRUE,
+    makecheck = FALSE,
     parallel = FALSE
   )
   
@@ -475,7 +476,6 @@ likelihood_lm3ppa <- function(
       Density = mean(Density12),
       Biomass = mean(plantC)
     )
-  
   
   # reshuffle observed data
   col_names <- obs$data[[1]]$variables
@@ -512,7 +512,9 @@ likelihood_lm3ppa <- function(
   logpost <- sum(unlist(logpost))
   
   # trap boundary conditions
-  if(is.nan(logpost) | is.na(logpost) | logpost == 0 ){logpost <- -Inf}
+  if(is.nan(logpost) | is.na(logpost) | logpost == 0 ){
+      logpost <- -Inf
+    }
   
   return(logpost)
 }

--- a/tests/testthat/test-calibration-lm3ppa.R
+++ b/tests/testthat/test-calibration-lm3ppa.R
@@ -10,7 +10,7 @@ test_that("test calibration routine lm3ppa (Bayesiantools)", {
   # Mortality as DBH
   settings <- list(
     method              = "bayesiantools",
-    targets             = c("GPP","LAI","Density","Biomass"),
+    targets             = c("GPP"), #,"LAI","Density","Biomass"),
     metric              = rsofun::likelihood_lm3ppa,
     control = list(
       sampler = "DEzs",
@@ -21,10 +21,11 @@ test_that("test calibration routine lm3ppa (Bayesiantools)", {
       )
     ),
     par = list(
-      phiRL = list(lower=0.5, upper=5, init=3.5),
-      LAI_light = list(lower=2, upper=5, init=3.5),
-      tf_base = list(lower=0.5, upper=1.5, init=1),
-      par_mort = list(lower=0.1, upper=2, init=1),
+      phiRL = list(lower = 0.5, upper = 5, init = 3.5),
+      LAI_light = list(lower = 2, upper = 5, init = 3.5),
+      tf_base = list(lower = 0.1, upper = 1, init = 0.5),
+      par_mort = list(lower = 1, upper = 2, init = 1.1),
+
       # uncertainties
       err_GPP = list(lower = 0, upper = 30, init = 15),
       err_LAI = list(lower = 0, upper = 5, init = 3),
@@ -32,13 +33,13 @@ test_that("test calibration routine lm3ppa (Bayesiantools)", {
       err_Biomass = list(lower = 0, upper = 50, init = 45)
     )
   )
-  
+
   pars <- calib_sofun(
     drivers = df_drivers,
     obs = ddf_obs,
     settings = settings
   )
-  
+
   # test for correctly returned values
   expect_type(pars, "list")
 })

--- a/tests/testthat/test-calibration-pmodel.R
+++ b/tests/testthat/test-calibration-pmodel.R
@@ -5,6 +5,7 @@ test_that("test calibration routine p-model (BT)", {
   skip_on_cran()
   drivers <- p_model_drivers
   obs <- rsofun::p_model_validation
+  
   settings <- list(
     method              = "bayesiantools",
     targets             = c("gpp"),
@@ -26,11 +27,13 @@ test_that("test calibration routine p-model (BT)", {
       err_gpp = list(lower = 0, upper = 30, init = 15)
     )
   )
+  
   pars <- calib_sofun(
     drivers = drivers,
     obs = obs,
     settings = settings
   )
+  
   # test for correctly returned values
   expect_type(pars, "list")
 })


### PR DESCRIPTION
Segfault issue fix, due to out of range `tf_base` parameter (< 0 or extremely small) as set by the BT priors routine. Permanent fix would be to hard code or set the parameter to a range 0 - 1 in Fortran.



