### PR TITLE
bugfix for calib_sofun

### DIFF
--- a/R/calib_sofun.R
+++ b/R/calib_sofun.R
@@ -94,7 +94,11 @@ calib_sofun <- function(
                 list(
                   par = random_par,
                   obs = obs,
-                  drivers = drivers
+                  drivers = drivers,
+                  # This is a hack. BayesianTools expects a likelihood function to be calculated here, 
+                  # but we're just calculating the RMSE and return its inverse (we want the RMSE 
+                  # minimised, its inverse maximised - imitating likelihood maximisation)
+                  inverse = TRUE     
                 ))
       },
       prior = priors,

--- a/R/calib_sofun.R
+++ b/R/calib_sofun.R
@@ -93,9 +93,7 @@ calib_sofun <- function(
         do.call("cost",
                 list(
                   par = random_par,
-                  par_names = par_names,
                   obs = obs,
-                  targets = settings$targets,
                   drivers = drivers
                 ))
       },

--- a/R/calib_sofun.R
+++ b/R/calib_sofun.R
@@ -84,26 +84,63 @@ calib_sofun <- function(
       unlist(pars$init)
     )
     
-    # setup the bayes run, no message forwarding is provided
-    # so wrap the function in a do.call
-    setup <- BayesianTools::createBayesianSetup(
-      likelihood = function(
-        random_par,
-        par_names = names(settings$par)) {
-        do.call("cost",
-                list(
-                  par = random_par,
-                  obs = obs,
-                  drivers = drivers,
-                  # This is a hack. BayesianTools expects a likelihood function to be calculated here, 
-                  # but we're just calculating the RMSE and return its inverse (we want the RMSE 
-                  # minimised, its inverse maximised - imitating likelihood maximisation)
-                  inverse = TRUE     
-                ))
-      },
-      prior = priors,
-      names = names(settings$par)
-    )
+    ## Hack: determine whether cost function is a bayesian-style likelihood function or a "traditional" cost function
+    ## traditional cost functions as implemented here have an argument 'inverse'. Use that to determine and if so
+    ## set it to TRUE to use the cost function.
+    ## solution with 'header' is based on https://stackoverflow.com/questions/30125590/how-can-a-function-return-its-name-and-arguments-in-r 
+    ## this may break if argument 'inverse' is abandoned and a better solution should be found eventually.
+    header <- function(x){
+      UseMethod('header', x)
+    }
+    header.function <-function(x){
+      y<-list(args(x))
+      x<-as.character(substitute(x))
+      print(sprintf('%s=%s',x,y))
+    }
+    if (grepl("inverse" , header(cost))){
+
+      # setup the bayes run, no message forwarding is provided
+      # so wrap the function in a do.call
+      setup <- BayesianTools::createBayesianSetup(
+        likelihood = function(
+          random_par,
+          par_names = names(settings$par)) {
+                do.call("cost",
+                        list(
+                          par = random_par,
+                          obs = obs,
+                          drivers = drivers,
+                          # This is a hack. BayesianTools expects a likelihood function to be calculated here, 
+                          # but we're just calculating the RMSE and return its inverse (we want the RMSE 
+                          # minimised, its inverse maximised - imitating likelihood maximisation)
+                          inverse = TRUE     
+                        ))
+              },
+          prior = priors,
+          names = names(settings$par)
+        )    
+      
+    } else {
+
+      # setup the bayes run, no message forwarding is provided
+      # so wrap the function in a do.call
+      setup <- BayesianTools::createBayesianSetup(
+        likelihood = function(
+          random_par,
+          par_names = names(settings$par)) {
+                do.call("cost",
+                        list(
+                          par = random_par,
+                          par_names = par_names,
+                          obs = obs,
+                          targets = settings$targets,
+                          drivers = drivers
+                        ))
+              },
+          prior = priors,
+          names = names(settings$par)
+        )   
+    }
     
     # set bt control parameters
     bt_settings <- settings$control$settings

--- a/R/cost_functions.R
+++ b/R/cost_functions.R
@@ -425,7 +425,6 @@ cost_rmse_lm3ppa_gsleuning <- function(
 #' @param obs observations
 #' @param targets target observations to use in calibration
 #' @param drivers driver data
-#' @param inverse invert the function (used here for compatibility)
 #' 
 #' @importFrom magrittr '%>%'
 #' @return the loglikelihood comparing observed and estimated values
@@ -436,8 +435,7 @@ likelihood_lm3ppa <- function(
   par_names,
   obs,
   targets,
-  drivers,
-  inverse = FALSE
+  drivers
 ){
   
   # predefine variables for CRAN check compliance
@@ -530,7 +528,6 @@ likelihood_lm3ppa <- function(
 #' @param obs observations
 #' @param targets target observations to use in calibration
 #' @param drivers driver data
-#' @param inverse invert the function (used here for compatibility)
 #' 
 #' @importFrom magrittr '%>%'
 #' 
@@ -542,8 +539,7 @@ likelihood_pmodel <- function(
   par_names,
   obs,
   targets,
-  drivers,
-  inverse = FALSE
+  drivers
 ){
   
   # predefine variables for CRAN check compliance
@@ -619,8 +615,7 @@ likelihood_pmodel <- function(
   return(logpost)
 }
 
-likelihood <- function (predicted, observed, sd) 
-{
+likelihood <- function(predicted, observed, sd){
   notNAvalues = !is.na(observed)
   return(
     sum(

--- a/R/cost_functions.R
+++ b/R/cost_functions.R
@@ -425,6 +425,7 @@ cost_rmse_lm3ppa_gsleuning <- function(
 #' @param obs observations
 #' @param targets target observations to use in calibration
 #' @param drivers driver data
+#' @param inverse invert the function (used here for compatibility)
 #' 
 #' @importFrom magrittr '%>%'
 #' @return the loglikelihood comparing observed and estimated values
@@ -435,7 +436,8 @@ likelihood_lm3ppa <- function(
   par_names,
   obs,
   targets,
-  drivers
+  drivers,
+  inverse = FALSE
 ){
   
   # predefine variables for CRAN check compliance
@@ -528,6 +530,7 @@ likelihood_lm3ppa <- function(
 #' @param obs observations
 #' @param targets target observations to use in calibration
 #' @param drivers driver data
+#' @param inverse invert the function (used here for compatibility)
 #' 
 #' @importFrom magrittr '%>%'
 #' 
@@ -539,7 +542,8 @@ likelihood_pmodel <- function(
   par_names,
   obs,
   targets,
-  drivers
+  drivers,
+  inverse = FALSE
 ){
   
   # predefine variables for CRAN check compliance

--- a/vignettes/pmodel_use.Rmd
+++ b/vignettes/pmodel_use.Rmd
@@ -125,7 +125,7 @@ settings <- list(
       iterations = 1500
     )),
   par = list(
-    kphio = list(lower=0.04, upper=0.1, init = 0.05)
+    kphio = list(lower=0.04, upper=0.2, init = 0.05)
     )
 )
 ```


### PR DESCRIPTION
Arguments passed to cost function via do.call did not correspond to arguments required by cost function.
This solves #81. 

(Increasing range of search is for more insightful testing).